### PR TITLE
Fix like model test that cannot read property 'id' of null

### DIFF
--- a/models/like.js
+++ b/models/like.js
@@ -3,6 +3,11 @@ module.exports = (sequelize, DataTypes) => {
   const Like = sequelize.define(
     'Like',
     {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+      },
       UserId: DataTypes.INTEGER,
       TweetId: DataTypes.INTEGER
     },


### PR DESCRIPTION
找到解法，就是在 like 的 model 上也要加上 autoIncrement: true( 原本 like 的 migration 有 )，跑測試後 like model 就會過。

參考資料：
https://github.com/sequelize/sequelize/issues/7689
https://github.com/sequelize/sequelize/issues/4374